### PR TITLE
Mapper 71 fixes for #389

### DIFF
--- a/src/boards/71.cpp
+++ b/src/boards/71.cpp
@@ -21,6 +21,7 @@
 #include "mapinc.h"
 
 static uint8 preg, mirr;
+static int hardmirr;
 
 static SFORMAT StateRegs[] =
 {
@@ -35,6 +36,8 @@ static void Sync(void) {
 	setchr8(0);
 	if(mirr)
 		setmirror(mirr);
+	else
+		setmirror(hardmirr); // restore hardwired mirroring
 }
 
 static DECLFW(M71Write) {
@@ -46,6 +49,7 @@ static DECLFW(M71Write) {
 }
 
 static void M71Power(void) {
+	preg = 0;
 	mirr = 0;
 	Sync();
 	SetReadHandler(0x8000, 0xFFFF, CartBR);
@@ -57,6 +61,7 @@ static void StateRestore(int version) {
 }
 
 void Mapper71_Init(CartInfo *info) {
+	hardmirr = info->mirror;
 	info->Power = M71Power;
 	GameStateRestore = StateRestore;
 


### PR DESCRIPTION
1. The mapper implementation ambiguously supports hardwired and switchable mirroring. It's assumed hardwired until the mirroring register is written but #389 exposes the fact that the hardwired status isn't restored on savestate.

2. preg was left uninitialized.