### PR TITLE
fix loading of keyboard mapping for controllers > 1

### DIFF
--- a/src/drivers/Qt/sdl-joystick.cpp
+++ b/src/drivers/Qt/sdl-joystick.cpp
@@ -31,6 +31,7 @@
 //#include <unistd.h>
 //#include <fcntl.h>
 #include <cerrno>
+#include <cstring>
 
 //#define MAX_JOYSTICKS	32
 
@@ -414,7 +415,7 @@ int GamePad_t::init(int port, const char *guid, const char *profile)
 
 	// If we get to this point and still have not found a
 	// game controller, then load default keyboard.
-	if ((portNum == 0) && (devIdx < 0))
+	if ((portNum == 0 || strnlen(profile, 1) > 0) && (devIdx < 0))
 	{
 		if (loadProfile(profile))
 		{


### PR DESCRIPTION
**Bad behavior fixed:**

1. With Qt driver
2. Load a ROM
3. Go to "Options -> GamePad Config"
4. Configure console ports 1 and 2 with a keyboard device, on two different profiles
5. Save the profiles under different names
6. Close GamePad Config window

At this point, you can use your key binding as espected. fceux.cfg is updated with correct profile info for both `SDL.Input.Gamepad.0.Profile` and  `SDL.Input.Gamepad.1.Profile`.

7. Close fceux
8. Restart fceux
9. Reload the ROM

At this point, GamePad 2's binding is not loaded.

**Fix summary:**

Load configured keyboard bindings for any gamepad.
Continue to load the default keyboard mapping if there is none configured only for the first gamepad.
