### PR TITLE
Only enable bus conflict for submapper 2 (mapper 2, mapper 3)

### DIFF
--- a/src/boards/datalatch.cpp
+++ b/src/boards/datalatch.cpp
@@ -180,7 +180,7 @@ static void UNROMSync(void) {
 }
 
 void UNROM_Init(CartInfo *info) {
-	Latch_Init(info, UNROMSync, 0, 0x8000, 0xFFFF, 0, 1);
+	Latch_Init(info, UNROMSync, 0, 0x8000, 0xFFFF, 0, info->ines2 && info->submapper == 2);
 }
 
 //------------------ Map 3 ---------------------------
@@ -192,7 +192,7 @@ static void CNROMSync(void) {
 }
 
 void CNROM_Init(CartInfo *info) {
-	Latch_Init(info, CNROMSync, 0, 0x8000, 0xFFFF, 1, 1);
+	Latch_Init(info, CNROMSync, 0, 0x8000, 0xFFFF, 1, info->ines2 && info->submapper == 2);
 }
 
 //------------------ Map 7 ---------------------------


### PR DESCRIPTION

Fix https://github.com/TASEmulators/fceux/issues/460

https://wiki.nesdev.org/w/index.php?title=NES_2.0_submappers#002.2C_003.2C_007:_UxROM.2C_CNROM.2C_AxROM