### PR TITLE
Mapper 225: Implement extra RAM

### DIFF
--- a/src/boards/225.cpp
+++ b/src/boards/225.cpp
@@ -52,15 +52,23 @@ static DECLFW(M225Write) {
 }
 
 static DECLFW(M225LoWrite) {
+	if (A & 0x800) {
+		prot[A & 0x03] = V;
+	}
 }
 
 static DECLFR(M225LoRead) {
-	return 0;
+	if (A & 0x800) {
+		return prot[A & 3] & 0x0F;
+	}
+	return X.DB;
 }
 
 static void M225Power(void) {
 	prg = 0;
+	chr = 0;
 	mode = 0;
+	mirr = 0;
 	Sync();
 	SetReadHandler(0x5000, 0x5FFF, M225LoRead);
 	SetWriteHandler(0x5000, 0x5FFF, M225LoWrite);
@@ -70,7 +78,9 @@ static void M225Power(void) {
 
 static void M225Reset(void) {
 	prg = 0;
+	chr = 0;
 	mode = 0;
+	mirr = 0;
 	Sync();
 }
 


### PR DESCRIPTION
Some multicarts are buggy without extra ram implemented,

Fix https://github.com/TASEmulators/fceux/issues/467