### PR TITLE
Add length checks to configuration file loading

### DIFF
--- a/src/drivers/common/config.cpp
+++ b/src/drivers/common/config.cpp
@@ -145,6 +145,11 @@ static void GetValueR(FILE *fp, char *str, void *v, int c)
 		{
 			if(!c)	// String, allocate some memory.
 			{
+				// Windows enforces a 32767 character limit for text boxes by default
+				// If a string exceeds this length, it's probably a corrupt file
+				if (s > 32768)
+					goto gogl;
+
 				if(!(*(char **)v=(char*)malloc(s)))
 					goto gogl;
 				


### PR DESCRIPTION
Adds some length checks to things to guard against loading a corrupt file, and prevent crashes.  Should fix #494

For the function `loadDebuggerPreferences`:

* Number of bookmarks, currently set to a max of 65536, which is a ridiculously high number of bookmarks.  Should the limit be set lower?
* Length of Breakpoint condition now set to a max of 32767 characters (which is way more than anyone would type in that tiny textbox)
* Length of Breakpoint description now set to a max of 32767 characters, also way more than anyone would actually type in

For the function `loadHexPreferences`:

* Length of a description is capped at 50 to prevent a buffer overflow.
* Number of shortcut matches is capped at 10.  I am unsure about this part, as the loader code is applying modulo 10 after reading an index to keep it in bounds.  Will .deb files ever specify more than 10 here?

For the function `GetValueR`:

* Limit the length of a string value read from a file to be 32767 characters.
