### PR TITLE
Qt GUI Patches

### DIFF
--- a/pipelines/linux_build.sh
+++ b/pipelines/linux_build.sh
@@ -98,7 +98,7 @@ sudo apt-get --assume-yes  install libavcodec-dev
 sudo apt-get --assume-yes  install libavformat-dev
 sudo apt-get --assume-yes  install libavutil-dev
 sudo apt-get --assume-yes  install libswscale-dev
-sudo apt-get --assume-yes  install libavresample-dev
+sudo apt-get --assume-yes  install libswresample-dev
 
 # Install cppcheck
 echo '****************************************'

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -578,7 +578,7 @@ set(SOURCES ${SRC_CORE} ${SRC_DRIVERS_COMMON} ${SRC_DRIVERS_SDL})
 # the FCEUX_BUILD_TIMESTAMP preprocessor definition.
 # Note: with CMake >= 3.8.0, this will respect SOURCE_DATE_EPOCH. For more info,
 #       see <https://reproducible-builds.org/docs/source-date-epoch/>.
-string(TIMESTAMP BUILD_TS "%H:%M:%S  %b %d %Y")
+string(TIMESTAMP BUILD_TS "%H:%M:%S  %b %d %Y" UTC)
 add_definitions( -DFCEUX_BUILD_TIMESTAMP=\"${BUILD_TS}\" )
 
 if (WIN32)

--- a/src/drivers/Qt/ConsoleViewerGL.cpp
+++ b/src/drivers/Qt/ConsoleViewerGL.cpp
@@ -84,6 +84,7 @@ ConsoleViewGL_t::ConsoleViewGL_t(QWidget *parent)
 	setMinimumWidth( 256 );
 	setMinimumHeight( 224 );
 	setFocusPolicy(Qt::StrongFocus);
+	//setAttribute(Qt::WA_OpaquePaintEvent);
 
 	localBufSize = (4 * GL_NES_WIDTH) * (4 * GL_NES_HEIGHT) * sizeof(uint32_t);
 
@@ -272,6 +273,8 @@ void ConsoleViewGL_t::buildTextures(void)
 						GL_BGRA, GL_UNSIGNED_BYTE, 0 );
 	}
 
+	glEnable(GL_BLEND);
+	glBlendFunc(GL_ONE_MINUS_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 	//printf("Texture Built: %ix%i\n", w, h);
 }
 
@@ -347,7 +350,7 @@ void ConsoleViewGL_t::initializeGL(void)
 	initializeOpenGLFunctions();
 	// Set up the rendering context, load shaders and other resources, etc.:
 	//QOpenGLFunctions *gl = QOpenGLContext::currentContext()->functions();
-	glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
+	glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
 
 	chkExtnsGL();
 	 //printf("GL Init!\n");
@@ -666,6 +669,8 @@ void ConsoleViewGL_t::paintGL(void)
 	}
 	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
+	glEnable(GL_BLEND);
+	glBlendFunc(GL_ONE_MINUS_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
 	if ( textureType == GL_TEXTURE_RECTANGLE )
 	{

--- a/src/drivers/Qt/ConsoleViewerGL.cpp
+++ b/src/drivers/Qt/ConsoleViewerGL.cpp
@@ -274,7 +274,8 @@ void ConsoleViewGL_t::buildTextures(void)
 	}
 
 	glEnable(GL_BLEND);
-	glBlendFunc(GL_ONE_MINUS_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+	glBlendFunc(GL_ONE, GL_ONE);
+	//glBlendFunc(GL_ONE_MINUS_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 	//printf("Texture Built: %ix%i\n", w, h);
 }
 
@@ -670,7 +671,8 @@ void ConsoleViewGL_t::paintGL(void)
 	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
 	glEnable(GL_BLEND);
-	glBlendFunc(GL_ONE_MINUS_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+	glBlendFunc(GL_ONE, GL_ONE);
+	//glBlendFunc(GL_ONE_MINUS_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
 	if ( textureType == GL_TEXTURE_RECTANGLE )
 	{

--- a/src/drivers/Qt/HexEditor.cpp
+++ b/src/drivers/Qt/HexEditor.cpp
@@ -4205,6 +4205,12 @@ int hexEditorOpenFromDebugger( int mode, int addr )
 
 		win->show();
 	}
+	else
+	{
+		win->activateWindow();
+		win->raise();
+		win->setFocus();
+	}
 
 	win->editor->setMode( mode );
 	win->editor->setAddr( addr );


### PR DESCRIPTION
Fixes openGL alpha blending on wayland systems #513 .
Incorporates debian reproducible builds patch.
Hex editor focus when opened via debugger #509 .
Fixes renamed libswresample-dev dependency in linux build script.