### PR TITLE
Memory initialization settings for PPU internal memory

### DIFF
--- a/src/ppu.cpp
+++ b/src/ppu.cpp
@@ -1734,10 +1734,17 @@ void FCEUPPU_Reset(void) {
 void FCEUPPU_Power(void) {
 	int x;
 
-	memset(NTARAM, 0x00, 0x800);
-	memset(PALRAM, 0x00, 0x20);
-	memset(UPALRAM, 0x00, 0x03);
-	memset(SPRAM, 0x00, 0x100);
+	// initialize PPU memory regions according to settings
+	FCEU_MemoryRand(NTARAM, 0x800, true);
+	FCEU_MemoryRand(PALRAM, 0x20, true);
+	FCEU_MemoryRand(SPRAM, 0x100, true);
+	// palettes can only store values up to $3F, and PALRAM X4/X8/XC are mirrors of X0 for rendering purposes (UPALRAM is used for $2007 readback)
+	for (x = 0; x < 0x20; ++x) PALRAM[x] &= 0x3F;
+	UPALRAM[0] = PALRAM[0x04];
+	UPALRAM[1] = PALRAM[0x08];
+	UPALRAM[2] = PALRAM[0x0C];
+	PALRAM[0x0C] = PALRAM[0x08] = PALRAM[0x04] = PALRAM[0x00];
+	PALRAM[0x1C] = PALRAM[0x18] = PALRAM[0x14] = PALRAM[0x10];
 	FCEUPPU_Reset();
 
 	for (x = 0x2000; x < 0x4000; x += 8) {


### PR DESCRIPTION
Nametables, sprites, and palettes were not using the memory initialization pattern setting.

The default 0-fill behaviour is retained, but $00/$FF/random settings will now apply as expected.