### PR TITLE
Fix build with GCC 13

### DIFF
--- a/src/drivers/Qt/AboutWindow.cpp
+++ b/src/drivers/Qt/AboutWindow.cpp
@@ -30,6 +30,7 @@
 #endif
 
 #ifdef _USE_X264
+#include <cstdint>
 #include "x264.h"
 #endif
 


### PR DESCRIPTION
GCC 13 (as usual for new compiler releases) shuffles around some internal includes and so etc is no longer transitively included.

See https://gnu.org/software/gcc/gcc-13/porting_to.html.

Bug: https://bugs.gentoo.org/900611