### PR TITLE
Remove redundant setFocus call, which actually removes focus.

### DIFF
--- a/src/drivers/Qt/CheatsConf.cpp
+++ b/src/drivers/Qt/CheatsConf.cpp
@@ -54,7 +54,6 @@ void openCheatDialog(QWidget *parent)
 	{
 		win->activateWindow();
 		win->raise();
-		win->setFocus();
 		return;
 	}
 	win = new GuiCheatsDialog_t(parent);

--- a/src/drivers/Qt/CodeDataLogger.cpp
+++ b/src/drivers/Qt/CodeDataLogger.cpp
@@ -63,7 +63,6 @@ int openCDLWindow( QWidget *parent )
 	{
 		cdlWin->activateWindow();
 		cdlWin->raise();
-		cdlWin->setFocus();
 	}
 	else
 	{

--- a/src/drivers/Qt/ConsoleDebugger.cpp
+++ b/src/drivers/Qt/ConsoleDebugger.cpp
@@ -4548,7 +4548,6 @@ void debuggerWindowSetFocus(bool val)
 	{
 		dbgWin->activateWindow();
 		dbgWin->raise();
-		dbgWin->setFocus();
 	}
 }
 //----------------------------------------------------------------------------

--- a/src/drivers/Qt/FamilyKeyboard.cpp
+++ b/src/drivers/Qt/FamilyKeyboard.cpp
@@ -126,7 +126,6 @@ int openFamilyKeyboardDialog(QWidget *parent)
 	{
 		fkbWin->activateWindow();
 		fkbWin->raise();
-		fkbWin->setFocus();
 	}
 	else
 	{

--- a/src/drivers/Qt/HexEditor.cpp
+++ b/src/drivers/Qt/HexEditor.cpp
@@ -4222,7 +4222,6 @@ int hexEditorOpenFromDebugger( int mode, int addr )
 	{
 		win->activateWindow();
 		win->raise();
-		win->setFocus();
 	}
 
 	win->editor->setMode( mode );

--- a/src/drivers/Qt/NameTableViewer.cpp
+++ b/src/drivers/Qt/NameTableViewer.cpp
@@ -108,7 +108,6 @@ int openNameTableViewWindow( QWidget *parent )
 	{
 		nameTableViewWindow->activateWindow();
 		nameTableViewWindow->raise();
-		nameTableViewWindow->setFocus();
 		return -1;
 	}
 	initNameTableViewer();

--- a/src/drivers/Qt/TasEditor/TasEditorWindow.cpp
+++ b/src/drivers/Qt/TasEditor/TasEditorWindow.cpp
@@ -116,7 +116,6 @@ void tasWindowSetFocus(bool val)
 	{
 		tasWin->activateWindow();
 		tasWin->raise();
-		tasWin->setFocus();
 	}
 }
 // this getter contains formula to decide whether to record or replay movie
@@ -2917,7 +2916,6 @@ void TasEditorWindow::openFindNoteWindow(void)
 	{
 		findWin->activateWindow();
 		findWin->raise();
-		findWin->setFocus();
 	}
 	else
 	{

--- a/src/drivers/Qt/TraceLogger.cpp
+++ b/src/drivers/Qt/TraceLogger.cpp
@@ -1211,7 +1211,6 @@ void openTraceLoggerWindow(QWidget *parent)
 	{
 		traceLogWindow->activateWindow();
 		traceLogWindow->raise();
-		traceLogWindow->setFocus();
 		return;
 	}
 	//printf("Open Trace Logger Window\n");

--- a/src/drivers/Qt/ppuViewer.cpp
+++ b/src/drivers/Qt/ppuViewer.cpp
@@ -92,7 +92,6 @@ int openPPUViewWindow( QWidget *parent )
 	{
 		ppuViewWindow->activateWindow();
 		ppuViewWindow->raise();
-		ppuViewWindow->setFocus();
 		return -1;
 	}
 	initPPUViewer();
@@ -110,7 +109,6 @@ int openOAMViewWindow( QWidget *parent )
 	{
 		spriteViewWindow->activateWindow();
 		spriteViewWindow->raise();
-		spriteViewWindow->setFocus();
 		return -1;
 	}
 	initPPUViewer();


### PR DESCRIPTION
I'm on i3wm 4.21.1/Qt 6.4.1.

This `activateWindow`/`raise`/`setFocus` pattern is used in several places to programmatically focus already opened windows. In my environment, this actually doesn't work to give keyboard focus to the new window, and I have to click the widget I want to focus before it gets keyboard events.

Removing the call to `setFocus` in these cases fixes the problem. The call to `activateWindow` is enough to put keyboard focus on it.

The documentation for [activateWindow](https://doc.qt.io/qt-5/qwidget.html#activateWindow) also implies that the call to it is enough to set keyboard focus.

I'd suspect the call to `setFocus` was originally tested and found necessary before the pattern was duplicated for different windows. Is anyone running Qt 5 and another window manager that can verify compatibility? If not, I can try to do that.