### PR TITLE
Don't index into empty QString in HexEditor.

### DIFF
--- a/src/drivers/Qt/HexEditor.cpp
+++ b/src/drivers/Qt/HexEditor.cpp
@@ -2777,7 +2777,13 @@ void QHexEdit::keyPressEvent(QKeyEvent *event)
 		event->accept();
 	}
 	else
-	{
+	{  // Use the input text to modify the values in the editor area.
+
+		if (event->text().isEmpty())
+		{
+			return;
+		}
+
 		int key;
 		if ( cursorPosX >= 32 )
 		{  // Edit Area is ASCII


### PR DESCRIPTION
`QKeyEvent::text` may return an empty string in some environments for some keys, such as modifier keys. This can cause a cause a crash. Add a check for the hex editor to skip the editing code, which assumes the keyboard event is a printable character and depends on a non-empty keyboard event text.