### PR TITLE
Don't always scroll to PC when updating debug window assembly view.

### DIFF
--- a/src/drivers/Qt/ConsoleDebugger.h
+++ b/src/drivers/Qt/ConsoleDebugger.h
@@ -167,6 +167,8 @@ class QAsmView : public QWidget
 
 		QFont getFont(void){ return font; };
 
+		enum UpdateType { UPDATE_NONE, UPDATE_ALL, UPDATE_NO_SCROLL };
+
 	protected:
 		bool event(QEvent *event) override;
 		void paintEvent(QPaintEvent *event) override;
@@ -471,7 +473,7 @@ class ConsoleDebugger : public QDialog
 		ConsoleDebugger(QWidget *parent = 0);
 		~ConsoleDebugger(void);
 
-		void updateWindowData(void);
+		void updateWindowData(enum QAsmView::UpdateType type);
 		void updateRegisterView(void);
 		void updateTabVisibility(void);
 		void breakPointNotify(int bpNum);
@@ -480,7 +482,7 @@ class ConsoleDebugger : public QDialog
 		void setBookmarkSelectedAddress( int addr );
 		int  getBookmarkSelectedAddress(void){ return selBmAddrVal; };
 		void edit_BM_name( int addr );
-		void queueUpdate(void);
+		void queueUpdate(enum QAsmView::UpdateType type);
 
 		QLabel    *asmLineSelLbl;
 
@@ -573,7 +575,8 @@ class ConsoleDebugger : public QDialog
 		ColorMenuItem *pcColorAct;
 
 		int   selBmAddrVal;
-		bool  windowUpdateReq;
+		enum QAsmView::UpdateType windowUpdateReq;
+
 		bool  startedTraceLogger;
 
 	private:
@@ -668,6 +671,6 @@ void saveGameDebugBreakpoints( bool force = false );
 void loadGameDebugBreakpoints(void);
 void debuggerClearAllBreakpoints(void);
 void debuggerClearAllBookmarks(void);
-void updateAllDebuggerWindows(void);
+void updateAllDebuggerWindows(enum QAsmView::UpdateType type);
 
 extern debuggerBookmarkManager_t dbgBmMgr;

--- a/src/drivers/Qt/HexEditor.cpp
+++ b/src/drivers/Qt/HexEditor.cpp
@@ -399,7 +399,7 @@ static int writeMem( int mode, unsigned int addr, int value )
 	{
 		if (debuggerWindowIsOpen())
 		{
-			updateAllDebuggerWindows();
+			updateAllDebuggerWindows(QAsmView::UPDATE_NO_SCROLL);
 		}
 	}
 
@@ -1853,7 +1853,7 @@ void HexEditorDialog_t::openDebugSymbolEditWindow( int addr )
 
 	if ( ret == QDialog::Accepted )
 	{
-		updateAllDebuggerWindows();
+		updateAllDebuggerWindows(QAsmView::UPDATE_NO_SCROLL);
 	}
 }
 //----------------------------------------------------------------------------
@@ -2830,6 +2830,7 @@ void QHexEdit::keyPressEvent(QKeyEvent *event)
 		}
 		else
 		{  // Edit Area is Hex
+
 		   key = int(event->text()[0].toUpper().toLatin1());
 		
 		   if ( ::isxdigit( key ) )

--- a/src/drivers/Qt/TraceLogger.cpp
+++ b/src/drivers/Qt/TraceLogger.cpp
@@ -57,6 +57,7 @@
 
 #include "common/os_utils.h"
 
+#include "Qt/ConsoleDebugger.h"
 #include "Qt/ConsoleWindow.h"
 #include "Qt/ConsoleUtilities.h"
 #include "Qt/TraceLogger.h"
@@ -2187,7 +2188,7 @@ void QTraceLogView::openBpEditWindow(int editIdx, watchpointinfo *wp, traceRecor
 					numWPs++;
 				}
 
-				updateAllDebuggerWindows();
+				updateAllDebuggerWindows(QAsmView::UPDATE_NO_SCROLL);
 			}
 		}
 	}
@@ -2232,7 +2233,7 @@ void QTraceLogView::openDebugSymbolEditWindow(int addr, int bank)
 
 	if (ret == QDialog::Accepted)
 	{
-		updateAllDebuggerWindows();
+		updateAllDebuggerWindows(QAsmView::UPDATE_NO_SCROLL);
 	}
 }
 //----------------------------------------------------------------------------


### PR DESCRIPTION
In the QT UI, I've been using the hex editor to quickly patch ROM code. The inline assembler doesn't seem to be supported in the QT version, although I could have overlooked it.

The existing behavior is to scroll the assembly view to the line of the current PC whenever a change is made in the hex editor. This is an issue with my use case, because I may want to change several instructions that are close to each other and verify the changes in the assembly as I go. The pull request proposes the changes.

--
Change ConsoleDebugger::updateWindowData and updateAllDebuggerWindows to support two different types of updates: UPDATE_ALL and UPDATE_NO_SCROLL. The new "no scroll" type lets callers request the assembly view be updated without scrolling the view to the PC line.

Change the hex editor and trace logger calls to updateAllDebuggerWindows to use the no scroll update. The user may use these functions with the current disassembly position in mind and not want to lose it.