### PR TITLE
Don't divide by 0 when PPU/sprite viewer windows are small.

### DIFF
--- a/src/drivers/Qt/ppuViewer.cpp
+++ b/src/drivers/Qt/ppuViewer.cpp
@@ -635,8 +635,8 @@ QPoint ppuPatternView_t::convPixToTile( QPoint p )
 	w = pattern->w;
 	h = pattern->h;
 
-	i = x / (w*8);
-	j = y / (h*8);
+	i = w == 0 ? 0 : x / (w*8);
+	j = h == 0 ? 0 : y / (h*8);
 
 	if ( PPUView_sprite16Mode[ patternIndex ] )
 	{
@@ -3336,8 +3336,8 @@ QPoint oamPatternView_t::convPixToTile( QPoint p )
 	w = oamPattern.w;
 	h = oamPattern.h;
 
-	i = x / (w*8);
-	j = y / (h*16);
+	i = w == 0 ? 0 : x / (w*8);
+	j = h == 0 ? 0 : y / (h*16);
 
 	//printf("(x,y) = (%i,%i) w=%i h=%i  $%X%X \n", x, y, w, h, jj, ii );
 


### PR DESCRIPTION
Some of the views are proportional to window dimensions. This caused division by 0 where window dimensions round down to 0. This change avoids that, instead setting those views' sizes to 0 in these cases.