### PR TITLE
Fixes for updating the cheats list.

### DIFF
--- a/src/drivers/Qt/CheatsConf.cpp
+++ b/src/drivers/Qt/CheatsConf.cpp
@@ -704,14 +704,10 @@ int GuiCheatsDialog_t::activeCheatListCB(const char *name, uint32 a, uint8 v, in
 
 	if (item == NULL)
 	{
-		item = new QTreeWidgetItem();
-
-		actvCheatList->addTopLevelItem(item);
+		item = new QTreeWidgetItem(actvCheatList);
 	}
 
-	//item->setFlags( Qt::ItemIsEnabled | Qt::ItemIsSelectable | Qt::ItemIsEditable | Qt::ItemIsUserCheckable );
 	item->setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable | Qt::ItemIsUserCheckable | Qt::ItemNeverHasChildren);
-
 	item->setCheckState(0, s ? Qt::Checked : Qt::Unchecked);
 
 	item->setText(0, tr(codeStr));
@@ -737,8 +733,6 @@ void GuiCheatsDialog_t::showActiveCheatList(bool redraw)
 
 	enaCheats->setChecked(!globalCheatDisabled);
 
-	actvCheatRedraw = redraw;
-
 	if (redraw)
 	{
 		actvCheatList->clear();
@@ -746,6 +740,8 @@ void GuiCheatsDialog_t::showActiveCheatList(bool redraw)
 	actvCheatIdx = 0;
 
 	FCEUI_ListCheats(::activeCheatListCB, (void *)this);
+
+	actvCheatList->viewport()->update();
 }
 //----------------------------------------------------------------------------
 void GuiCheatsDialog_t::openCheatFile(void)

--- a/src/drivers/Qt/CheatsConf.h
+++ b/src/drivers/Qt/CheatsConf.h
@@ -72,7 +72,6 @@ protected:
 
 	int fontCharWidth;
 	int actvCheatIdx;
-	bool actvCheatRedraw;
 	bool pauseWhileActive;
 	bool wasPausedByCheats;
 

--- a/src/drivers/Qt/GameGenie.cpp
+++ b/src/drivers/Qt/GameGenie.cpp
@@ -42,6 +42,7 @@
 #include "Qt/config.h"
 #include "Qt/keyscan.h"
 #include "Qt/fceuWrapper.h"
+#include "Qt/CheatsConf.h"
 #include "Qt/HexEditor.h"
 #include "Qt/GameGenie.h"
 
@@ -278,6 +279,7 @@ void GameGenieDialog_t::addCheatClicked(void)
 
 	FCEU_WRAPPER_LOCK();
 	FCEUI_AddCheat( name.c_str(), a, v, c, 1 );
+	updateCheatDialog();
 	FCEU_WRAPPER_UNLOCK();
 
 }


### PR DESCRIPTION
Update the cheats list after adding a new cheat from the Game Genie window. With this change, the new cheat is shown immediately in the cheats window, if it's open.

Fix an issue where the cheats list isn't always immediately updated after a change. For example, clicking Add while an item is already selected might not show the item until some other user action is taken. This change updates the cheats list `QTreeWidget` viewport explicitly after making changes to its items. This causes changes to be shown immediately.

Remove unused `GuiCheatsDialog_t::actvCheatRedraw` member.