### PR TITLE
MMC5: Fix PRG in 32K bank switching

### DIFF
--- a/src/boards/mmc5.cpp
+++ b/src/boards/mmc5.cpp
@@ -424,7 +424,7 @@ static void MMC5PRG(void) {
 	switch (mmc5psize & 3) {
 	case 0:
 		MMC5ROMWrProtect[0] = MMC5ROMWrProtect[1] = MMC5ROMWrProtect[2] = MMC5ROMWrProtect[3] = 1;
-		setprg32(0x8000, ((PRGBanks[1] & 0x7F) >> 2));
+		setprg32(0x8000, ((PRGBanks[3] & 0x7F) >> 2));
 		for (x = 0; x < 4; x++)
 			MMC5MemIn[1 + x] = 1;
 		break;


### PR DESCRIPTION
PRG register $5117 value is used for the entire $8000-$FFFF CPU range in 32K mode.

See https://www.nesdev.org/wiki/MMC5#PRG_mode_($5100) in PRG bankswitching