### PR TITLE
Write instructions now update the databus

### DIFF
--- a/src/x6502.cpp
+++ b/src/x6502.cpp
@@ -61,6 +61,7 @@ static INLINE void WrMem(unsigned int A, uint8 V)
 	#ifdef _S9XLUA_H
 	CallRegisteredLuaMemHook(A, 1, V, LUAMEMHOOK_WRITE);
 	#endif
+    _DB = V;
 }
 
 static INLINE uint8 RdRAM(unsigned int A)
@@ -80,6 +81,7 @@ static INLINE void WrRAM(unsigned int A, uint8 V)
 	#ifdef _S9XLUA_H
 	CallRegisteredLuaMemHook(A, 1, V, LUAMEMHOOK_WRITE);
 	#endif
+    _DB = V;
 }
 
 uint8 X6502_DMR(uint32 A)
@@ -99,6 +101,7 @@ void X6502_DMW(uint32 A, uint8 V)
  #ifdef _S9XLUA_H
  CallRegisteredLuaMemHook(A, 1, V, LUAMEMHOOK_WRITE);
  #endif
+ _DB = V;
 }
 
 #define PUSH(V) \


### PR DESCRIPTION
This corrects open bus execution following write instructions.

The example used here is from the exploit showcased in [this video](https://www.youtube.com/watch?v=xoDakIA31jc).

After an indirect jump to open bus, the SRE instruction will execute, shifting address $0010 from a value of 0x80 to 0x40, however 0x80 remained on the databus.

![DB_before](https://github.com/TASEmulators/fceux/assets/23084831/1989cb50-87b9-4aa2-94c4-0dcb2d599454)

Write instructions update the databus, so the corrected behavior would leave 0x40 on the databus.

![DB_after](https://github.com/TASEmulators/fceux/assets/23084831/ed5acf7d-fb57-4322-a0d1-3a5610ff6a90)

This databus behavior with write instructions can also be seen on Visual6502

![232245342-283bda67-de87-45f0-9a0a-4c74b5d013fe](https://github.com/TASEmulators/fceux/assets/23084831/6cd1ef1a-274a-431c-82fd-30160d522d38)
