### PR TITLE
Fix 128K CHR-ROM variants for VRC5

### DIFF
--- a/src/pputile.inc
+++ b/src/pputile.inc
@@ -87,9 +87,14 @@ pshift[1] <<= 8;
 	#else
 
 	#ifdef PPU_VRC5FETCH
-	if(tmpd & 0x40)
+	if(tmpd & 0x40) {
+		if (CHRsize[0] == (128 * 1024)) {
+			// NOTE: address 128K CHR-ROM using offsets into 256K CHR-ROM data
+			// https://www.nesdev.org/wiki/NES_2.0_Mapper_547#Kanji_ROM_layout
+			vadr = ((vadr & 0x00007) << 1) | ((vadr & 0x00010) >> 4) | ((vadr & 0x3FFE0) >> 1);
+		}
 		C = CHRptr[0] + vadr;
-	else
+	} else
 		C = VRAMADR(vadr);
 	#else
 		C = VRAMADR(vadr);


### PR DESCRIPTION
This fixes handling of 128K chr rom variants based on updated info on nesdev. there is also a new formula for Character Translation Operation that can be used i f needed.

https://www.nesdev.org/wiki/NES_2.0_Mapper_547#Kanji_ROM_layout

@g0me3 