### PR TITLE
Clip Left/Right Sides option now taken into account when using NTSC s…

### DIFF
--- a/src/drivers/Qt/sdl-video.cpp
+++ b/src/drivers/Qt/sdl-video.cpp
@@ -168,7 +168,7 @@ void CalcVideoDimensions(void)
 	int iScale = nes_shm->video.xscale;
 	if ( s_sponge == 3 )
 	{
-		nes_shm->video.ncol = iScale*301;
+		nes_shm->video.ncol = iScale*(301-(ClipSidesOffset ? 21 : 0));
 	}
 	else
 	{
@@ -264,7 +264,7 @@ int InitVideo(FCEUGI *gi)
 	int iScale = nes_shm->video.xscale;
 	if ( s_sponge == 3 )
 	{
-		nes_shm->video.ncol = iScale*301;
+		nes_shm->video.ncol = iScale*(301-(ClipSidesOffset ? 21 : 0));
 	}
 	else
 	{
@@ -446,7 +446,7 @@ doBlitScreen(uint8_t *XBuf, uint8_t *dest)
 
 	if ( s_sponge == 3 )
 	{
-		w = ixScale*301;
+		w = ixScale*(301-(ClipSidesOffset ? 21 : 0));
 		bw = 256;
 	}
 	else
@@ -539,7 +539,7 @@ uint32 PtoV(double nx, double ny)
 
 	if ( nes_shm->video.preScaler == 3 )
 	{
-		x = (int)( nx * (double)nes_shm->video.ncol * (256.0/301.0) );
+		x = (int)( nx * (double)nes_shm->video.ncol * (256.0/(301.0-(ClipSidesOffset ? 21 : 0))) );
 	}
 	else
 	{

--- a/src/drivers/Qt/sdl-video.cpp
+++ b/src/drivers/Qt/sdl-video.cpp
@@ -62,8 +62,10 @@ static int s_fullscreen = 0;
 static int noframe = 0;
 static int initBlitToHighDone = 0;
 
-#define NWIDTH	(256 - (s_clipSides ? 16 : 0))
-#define NOFFSET	(s_clipSides ? 8 : 0)
+#define NWIDTH	  (256 - (s_clipSides ? 16 : 0))
+#define NOFFSET	  (s_clipSides ? 8 : 0)
+
+#define NTSCWIDTH (301 - (s_clipSides ? 19 : 0))
 
 static int s_paletterefresh = 1;
 
@@ -168,7 +170,7 @@ void CalcVideoDimensions(void)
 	int iScale = nes_shm->video.xscale;
 	if ( s_sponge == 3 )
 	{
-		nes_shm->video.ncol = iScale*(301-(ClipSidesOffset ? 21 : 0));
+		nes_shm->video.ncol = iScale*NTSCWIDTH;
 	}
 	else
 	{
@@ -264,7 +266,7 @@ int InitVideo(FCEUGI *gi)
 	int iScale = nes_shm->video.xscale;
 	if ( s_sponge == 3 )
 	{
-		nes_shm->video.ncol = iScale*(301-(ClipSidesOffset ? 21 : 0));
+		nes_shm->video.ncol = iScale*NTSCWIDTH;
 	}
 	else
 	{
@@ -446,7 +448,7 @@ doBlitScreen(uint8_t *XBuf, uint8_t *dest)
 
 	if ( s_sponge == 3 )
 	{
-		w = ixScale*(301-(ClipSidesOffset ? 21 : 0));
+		w = ixScale*NTSCWIDTH;
 		bw = 256;
 	}
 	else
@@ -539,7 +541,7 @@ uint32 PtoV(double nx, double ny)
 
 	if ( nes_shm->video.preScaler == 3 )
 	{
-		x = (int)( nx * (double)nes_shm->video.ncol * (256.0/(301.0-(ClipSidesOffset ? 21 : 0))) );
+		x = (int)( nx * (double)nes_shm->video.ncol * (256.0/301.0) );
 	}
 	else
 	{

--- a/src/drivers/common/vidblit.cpp
+++ b/src/drivers/common/vidblit.cpp
@@ -29,6 +29,7 @@
 #include "../../palette.h"
 #include "../../utils/memory.h"
 #include "nes_ntsc.h"
+#include "video.h"
 
 extern u8 *XBuf;
 extern u8 *XBackBuf;
@@ -858,10 +859,9 @@ void Blit8ToHigh(uint8 *src, uint8 *dest, int xr, int yr, int pitch, int xscale,
 			{
 			case 4:
 				if ( nes_ntsc && GameInfo && GameInfo->type!=GIT_NSF) {
-					int outxr = 301;
+					int outxr = 301 - (ClipSidesOffset ? 21 : 0);
 					//if(xr == 282) outxr = 282; //hack for windows
 					burst_phase ^= 1;
-
 					u8* srcD = XDBuf + (src-XBuf); // get deemphasis buffer
 					nes_ntsc_blit( nes_ntsc, (unsigned char*)src, (unsigned char*)srcD, xr, burst_phase, xr, yr, ntscblit, (2*outxr) * Bpp );
 

--- a/src/drivers/common/vidblit.cpp
+++ b/src/drivers/common/vidblit.cpp
@@ -859,7 +859,7 @@ void Blit8ToHigh(uint8 *src, uint8 *dest, int xr, int yr, int pitch, int xscale,
 			{
 			case 4:
 				if ( nes_ntsc && GameInfo && GameInfo->type!=GIT_NSF) {
-					int outxr = 301 - (ClipSidesOffset ? 21 : 0);
+					int outxr = 301 - (ClipSidesOffset ? 19 : 0);
 					//if(xr == 282) outxr = 282; //hack for windows
 					burst_phase ^= 1;
 					u8* srcD = XDBuf + (src-XBuf); // get deemphasis buffer


### PR DESCRIPTION
…caler

This otion fixes offsets in Clip Left/Right Sides option when using an NTSC 2x video scaler. Im unfamiliar with the UI, so the changes was only tested on Qt build, not entirely sure if there is anywhere else that the offset has to be accounted for.

@thor2016 

Fix https://github.com/TASEmulators/fceux/issues/679