### PR TITLE
QT: Fix volume adjustment for APU

### DIFF
--- a/src/drivers/Qt/ConsoleSoundConf.cpp
+++ b/src/drivers/Qt/ConsoleSoundConf.cpp
@@ -189,10 +189,10 @@ ConsoleSndConfDialog_t::ConsoleSndConfDialog_t(QWidget *parent)
 
 	frame = new QGroupBox(tr("Triangle"));
 	vbox2 = new QVBoxLayout();
-	triLbl = new QLabel("255");
+	triLbl = new QLabel("256");
 	vslider = new QSlider(Qt::Vertical);
 	vslider->setMinimum(0);
-	vslider->setMaximum(255);
+	vslider->setMaximum(256);
 	setSliderFromProperty(vslider, triLbl, "SDL.Sound.TriangleVolume");
 
 	vbox2->addWidget(triLbl);
@@ -204,10 +204,10 @@ ConsoleSndConfDialog_t::ConsoleSndConfDialog_t(QWidget *parent)
 
 	frame = new QGroupBox(tr("Square1"));
 	vbox2 = new QVBoxLayout();
-	sqr1Lbl = new QLabel("255");
+	sqr1Lbl = new QLabel("256");
 	vslider = new QSlider(Qt::Vertical);
 	vslider->setMinimum(0);
-	vslider->setMaximum(255);
+	vslider->setMaximum(256);
 	setSliderFromProperty(vslider, sqr1Lbl, "SDL.Sound.Square1Volume");
 
 	vbox2->addWidget(sqr1Lbl);
@@ -219,10 +219,10 @@ ConsoleSndConfDialog_t::ConsoleSndConfDialog_t(QWidget *parent)
 
 	frame = new QGroupBox(tr("Square2"));
 	vbox2 = new QVBoxLayout();
-	sqr2Lbl = new QLabel("255");
+	sqr2Lbl = new QLabel("256");
 	sqr2Slider = new QSlider(Qt::Vertical);
 	sqr2Slider->setMinimum(0);
-	sqr2Slider->setMaximum(255);
+	sqr2Slider->setMaximum(256);
 	setSliderFromProperty(sqr2Slider, sqr2Lbl, "SDL.Sound.Square2Volume");
 
 	vbox2->addWidget(sqr2Lbl);
@@ -234,10 +234,10 @@ ConsoleSndConfDialog_t::ConsoleSndConfDialog_t(QWidget *parent)
 
 	frame = new QGroupBox(tr("Noise"));
 	vbox2 = new QVBoxLayout();
-	nseLbl = new QLabel("255");
+	nseLbl = new QLabel("256");
 	nseSlider = new QSlider(Qt::Vertical);
 	nseSlider->setMinimum(0);
-	nseSlider->setMaximum(255);
+	nseSlider->setMaximum(256);
 	setSliderFromProperty(nseSlider, nseLbl, "SDL.Sound.NoiseVolume");
 
 	vbox2->addWidget(nseLbl);
@@ -249,10 +249,10 @@ ConsoleSndConfDialog_t::ConsoleSndConfDialog_t(QWidget *parent)
 
 	frame = new QGroupBox(tr("PCM"));
 	vbox2 = new QVBoxLayout();
-	pcmLbl = new QLabel("255");
+	pcmLbl = new QLabel("256");
 	pcmSlider = new QSlider(Qt::Vertical);
 	pcmSlider->setMinimum(0);
-	pcmSlider->setMaximum(255);
+	pcmSlider->setMaximum(256);
 	setSliderFromProperty(pcmSlider, pcmLbl, "SDL.Sound.PCMVolume");
 
 	vbox2->addWidget(pcmLbl);


### PR DESCRIPTION
Volume adjustments for the apu channel has a range of 0-256. With a value of 256, this acts as a bypass (toggle) and skips the computation entirely when set. This fixes issues when the original signal is too low already that passing it through volume controls will attunuate the signal instead and silence it.

The main volume does not behave the same way and 256 is not a toggle, so left it as-is.

@thor2016 feel free to make it better if necessary, maybe a toggle instead of a 256 max value or something.

Fix https://github.com/TASEmulators/fceux/issues/703