### PR TITLE
Non-SDL/Qt Windows Trace Logging Optimizations

### DIFF
--- a/src/drivers/Qt/ConsoleWindow.cpp
+++ b/src/drivers/Qt/ConsoleWindow.cpp
@@ -3190,24 +3190,16 @@ void consoleWin_t::openPaletteEditorWin(void)
 
 void consoleWin_t::openNetPlayHostWindow(void)
 {
-	NetPlayHostDialog *win;
-
 	//printf("Open NetPlay Host Window\n");
 	
-   win = new NetPlayHostDialog(this);
-	
-   win->show();
+	openNetPlayHostDialog(this);
 }
 
 void consoleWin_t::openNetPlayJoinWindow(void)
 {
-	NetPlayJoinDialog *win;
-
 	//printf("Open NetPlay Join Window\n");
 	
-   win = new NetPlayJoinDialog(this);
-	
-   win->show();
+	openNetPlayJoinDialog(this);
 }
 
 void consoleWin_t::closeNetPlaySession(void)

--- a/src/drivers/Qt/QtScriptManager.h
+++ b/src/drivers/Qt/QtScriptManager.h
@@ -604,6 +604,24 @@ public slots:
 	Q_INVOKABLE int  maxJoypadPlayers(){ return JoypadScriptObject::MAX_JOYPAD_PLAYERS; }
 };
 
+class ModuleLoaderObject: public QObject
+{
+	Q_OBJECT
+public:
+	ModuleLoaderObject(QObject* parent = nullptr);
+	~ModuleLoaderObject();
+
+	void setEngine(FCEU::JSEngine* _engine){ engine = _engine; }
+
+private:
+	FCEU::JSEngine* engine = nullptr;
+	QtScriptInstance* script = nullptr;
+	int scopeCounter = 0;
+
+public slots:
+	Q_INVOKABLE void GlobalImport(const QString& ns, const QString& file);
+};
+
 } // JS
 
 class ScriptExecutionState
@@ -659,6 +677,7 @@ public:
 
 	int  throwError(QJSValue::ErrorType errorType, const QString &message = QString());
 
+	const QString& getSrcFile(){ return srcFile; };
 	FCEU::JSEngine* getEngine(){ return engine; };
 private:
 
@@ -677,6 +696,7 @@ private:
 	JS::MemoryScriptObject* mem = nullptr;
 	JS::InputScriptObject* input = nullptr;
 	JS::MovieScriptObject* movie = nullptr;
+	JS::ModuleLoaderObject* moduleLoader = nullptr;
 	QWidget* ui_rootWidget = nullptr;
 	QJSValue *onFrameBeginCallback = nullptr;
 	QJSValue *onFrameFinishCallback = nullptr;
@@ -687,6 +707,7 @@ private:
 	int frameAdvanceCount = 0;
 	int frameAdvanceState = 0;
 	bool running = false;
+	QString srcFile;
 
 signals:
 	void errorNotify();

--- a/src/drivers/Qt/TraceLogger.cpp
+++ b/src/drivers/Qt/TraceLogger.cpp
@@ -924,21 +924,6 @@ int traceRecord_t::appendAsmText(const char *txt)
 	return 0;
 }
 //----------------------------------------------------
-static int convToXchar(int i)
-{
-	int c = 0;
-
-	if ((i >= 0) && (i < 10))
-	{
-		c = i + '0';
-	}
-	else if (i < 16)
-	{
-		c = (i - 10) + 'A';
-	}
-	return c;
-}
-//----------------------------------------------------
 int traceRecord_t::convToText(char *txt, int *len)
 {
 	int i = 0, j = 0;
@@ -2438,7 +2423,7 @@ void TraceLogDiskThread_t::run(void)
 	const unsigned bufSize = blockSize * 2;
 	const unsigned flushSize = blockSize;
 	char buf[bufSize];
-	int i, idx=0;
+	unsigned int i, idx=0;
 
 	logFile = open( logFilePath.c_str(), O_CREAT | O_WRONLY | O_TRUNC, 
 			S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH );

--- a/src/drivers/Qt/config.cpp
+++ b/src/drivers/Qt/config.cpp
@@ -35,6 +35,7 @@
 #include "Qt/sdl-video.h"
 #include "Qt/AviRecord.h"
 #include "Qt/unix-netplay.h"
+#include "Qt/NetPlay.h"
 #include "Qt/TasEditor/taseditor_config.h"
 
 #ifdef WIN32
@@ -618,13 +619,19 @@ InitConfig()
 	config->addOption("SDL.winFullScreenBorder", 0);
 	#endif
 
+	QString userName = qgetenv("USER");
+    	if (userName.isEmpty())
+	{
+        	userName = qgetenv("USERNAME");
+	}
+
 	// network play options - netplay is broken
 	config->addOption("server", "SDL.NetworkIsServer", 0);
-	config->addOption('n', "net", "SDL.NetworkIP", "");
-	config->addOption('u', "user", "SDL.NetworkUsername", "");
+	config->addOption('n', "net", "SDL.NetworkIP", "localhost");
+	config->addOption('u', "user", "SDL.NetworkUsername", userName.toLocal8Bit().constData());
 	config->addOption('w', "pass", "SDL.NetworkPassword", "");
 	config->addOption('k', "netkey", "SDL.NetworkGameKey", "");
-	config->addOption("port", "SDL.NetworkPort", 4046);
+	config->addOption("port", "SDL.NetworkPort", NetPlayServer::DefaultPort);
 	config->addOption("players", "SDL.NetworkPlayers", 1);
      
 	// input configuration options


### PR DESCRIPTION
Fix for #716.

Analogous changes to #714 for the non-SDL/Qt Windows build.

Annoying how GitHub's showing all the changes from #714 in the list of commits, when those were already merged to master (the changed files/lines appears correct, though).