### PR TITLE
"(z),Y" addressing incorrectly shown as "(z,Y)" in debugger

### DIFF
--- a/src/asm.cpp
+++ b/src/asm.cpp
@@ -337,10 +337,8 @@ char *Disassemble(int addr, uint8 *opcode) {
 		case 0xE1: chr = "SBC"; goto _indirectx;
 		_indirectx:
 			indirectX(tmp);
-			indReg = 'X';
 
-		_indirect:
-			sb << chr << " (" << sb_addr(opcode[1], 2) << ',' << indReg << ") @ " << sb_addr(tmp) << " = " << sb_lit(GetMem(tmp));
+			sb << chr << " (" << sb_addr(opcode[1], 2) << ",X) @ " << sb_addr(tmp) << " = " << sb_lit(GetMem(tmp));
 			break;
 
 		//Zero Page
@@ -445,9 +443,9 @@ char *Disassemble(int addr, uint8 *opcode) {
 		case 0xF1: chr = "SBC"; goto _indirecty;
 		_indirecty:
 			indirectY(tmp);
-			indReg = 'Y';
 
-			goto _indirect;
+			sb << chr << " (" << sb_addr(opcode[1], 2) << "),Y @ " << sb_addr(tmp) << " = " << sb_lit(GetMem(tmp));
+			break;
 
 		//Zero Page,X
 		case 0x15: chr = "ORA"; goto _zeropagex;

--- a/src/drivers/Qt/SymbolicDebug.cpp
+++ b/src/drivers/Qt/SymbolicDebug.cpp
@@ -164,13 +164,11 @@ int DisassembleWithDebug(int addr, uint8_t *opcode, int flags, char *str, debugS
 		case 0xE1: chr = "SBC"; goto _indirectx;
 		_indirectx:
 			indirectX(tmp);
-			indReg = 'X';
 
-		_indirect:
 			if ( symDebugEnable )
 				sym = replaceSymbols( flags, tmp, stmp );
 
-			sb << chr << " (" << sb_addr(opcode[1], 2) << ',' << indReg << ')';
+			sb << chr << " (" << sb_addr(opcode[1], 2) << ",X)";
 
 			if (showTrace)
 			{
@@ -315,9 +313,23 @@ int DisassembleWithDebug(int addr, uint8_t *opcode, int flags, char *str, debugS
 		case 0xF1: chr = "SBC"; goto _indirecty;
 		_indirecty:
 			indirectY(tmp);
-			indReg = 'Y';
 
-			goto _indirect;
+			if (symDebugEnable)
+				sym = replaceSymbols(flags, tmp, stmp);
+
+			sb << chr << " (" << sb_addr(opcode[1], 2) << "),Y";
+
+			if (showTrace)
+			{
+				sb << " @ ";
+				if (symDebugEnable)
+					sb << stmp;
+				else
+					sb << sb_addr(tmp);
+
+				sb << " = " << sb_lit(GetMem(tmp));
+			}
+			break;
 
 		//Zero Page,X
 		case 0x15: chr = "ORA"; goto _zeropagex;


### PR DESCRIPTION
Fixes #729 