### PR TITLE
Make X24C02 only enter read/write state if I2C address matches; fixes #731

### DIFF
--- a/src/boards/bandai.cpp
+++ b/src/boards/bandai.cpp
@@ -178,9 +178,12 @@ static void x24c02_write(uint8 data) {
 				x24c02_addr <<= 1;
 				x24c02_addr |= sda;
 			} else {
-				if (sda)					// READ COMMAND
+				if ((x24c02_addr & 0x78) != 0x50) {	// WRONG DEVICE ADDRESS
+					x24c02_out = 1;
+					x24c02_state = X24C0X_STANDBY;
+				} else if (sda)					// READ COMMAND
 					x24c02_state = X24C0X_READ;
-				else						// WRITE COMMAND
+				else							// WRITE COMMAND
 					x24c02_state = X24C0X_WORD;
 			}
 			x24c02_bitcount++;


### PR DESCRIPTION
I2C devices like the X24C02 EEPROM have a 7-bit device address that allows multiple devices to share an I2C bus. FCEUX's EEPROM emulation was completely ignoring the address, and unconditionally activating itself after any old 7 bits were written. This was causing SD Gundam Gaiden 2 to fail to communicate with the EEPROM properly.

This patch makes the EEPROM validate the upper 4 bits of the I2C address, which is good enough for SD Gundam Gaiden 2. I've verified that the patch doesn't break any of the other games with an X24C02.

Fixes #731 