### PR TITLE
Fix Linux build

### DIFF
--- a/src/drivers/Qt/AviRecord.cpp
+++ b/src/drivers/Qt/AviRecord.cpp
@@ -80,11 +80,11 @@ extern "C"
 static gwavi_t  *gwavi = NULL;
 static bool      recordEnable = false;
 static bool      recordAudio  = true;
-static std::atomic<int> vbufHead = 0;
-static std::atomic<int> vbufTail = 0;
+static std::atomic<int> vbufHead(0);
+static std::atomic<int> vbufTail(0);
 static constexpr int    vbufSize = 1024 * 1024 * 64;
-static std::atomic<int> abufHead = 0;
-static std::atomic<int> abufTail = 0;
+static std::atomic<int> abufHead(0);
+static std::atomic<int> abufTail(0);
 static constexpr int    abufSize = 256 * 1024;
 static uint32_t *rawVideoBuf = NULL;
 static int16_t  *rawAudioBuf = NULL;


### PR DESCRIPTION
FCEUX fails to build on Linux since ffb28e113168a1eb280ed8e786f92b781aae5f72

The build error is because copy initialization of `std::atomic` types requires a C++17 feature; see https://stackoverflow.com/questions/27314485/use-of-deleted-function-error-with-stdatomic-int