### PR TITLE
Fix attribution

### DIFF
--- a/src/drivers/Qt/AboutWindow.cpp
+++ b/src/drivers/Qt/AboutWindow.cpp
@@ -74,7 +74,7 @@ static const char *Authors[] = {
 		"\t rainwarrior", "\t feos",
 	"Pre 2.0 Guys:",
 	"\t Bero", "\t Xodnizel", "\t Aaron Oneal", "\t Joe Nahmias",
-	"\t Paul Kuliniewicz", "\t Quietust", "\t Ben Parnell",
+	"\t Paul Kuliniewicz", "\t Quietust",
 		"\t Parasyte &amp; bbitmaster",
 	"\t blip & nitsuja",
 	"Included components:",

--- a/src/drivers/sdl/gui.cpp
+++ b/src/drivers/sdl/gui.cpp
@@ -1496,7 +1496,7 @@ const char *Authors[] = {
 		"rainwarrior", "feos",
 	"Pre 2.0 Guys:",
 	" Bero", " Xodnizel", " Aaron Oneal", " Joe Nahmias",
-	" Paul Kuliniewicz", " Quietust", " Ben Parnell",
+	" Paul Kuliniewicz", " Quietust",
 		" Parasyte &amp; bbitmaster",
 	" blip &amp; nitsuja",
 	"Included components:",

--- a/src/drivers/win/cdlogger.cpp
+++ b/src/drivers/win/cdlogger.cpp
@@ -1,7 +1,7 @@
 /* FCE Ultra - NES/Famicom Emulator
  *
  * Copyright notice for this file:
- *  Copyright (C) 2002 Ben Parnell
+ *  Copyright (C) 2004 Ben Goodrich aka bbitmaster <bbitmaster@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/drivers/win/cheat.cpp
+++ b/src/drivers/win/cheat.cpp
@@ -1,7 +1,7 @@
 /* FCE Ultra - NES/Famicom Emulator
  *
  * Copyright notice for this file:
- *  Copyright (C) 2002 Ben Parnell
+ *  Copyright (C) 2002 Xodnizel, Jay Oster aka Parasyte <jay@kodewerx.org>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/drivers/win/debugger.cpp
+++ b/src/drivers/win/debugger.cpp
@@ -1,7 +1,7 @@
 /* FCE Ultra - NES/Famicom Emulator
  *
  * Copyright notice for this file:
- *  Copyright (C) 2002 Ben Parnell
+ *  Copyright (C) 2002 Jay Oster aka Parasyte <jay@kodewerx.org>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/drivers/win/memview.cpp
+++ b/src/drivers/win/memview.cpp
@@ -1,7 +1,7 @@
 /* FCE Ultra - NES/Famicom Emulator
 *
 * Copyright notice for this file:
-*  Copyright (C) 2002 Ben Parnell
+*  Copyright (C) 2004 Ben Goodrich aka bbitmaster <bbitmaster@gmail.com>
 *
 * This program is free software; you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by

--- a/src/drivers/win/ntview.cpp
+++ b/src/drivers/win/ntview.cpp
@@ -1,7 +1,7 @@
 /* FCE Ultra - NES/Famicom Emulator
  *
  * Copyright notice for this file:
- *  Copyright (C) 2002 Ben Parnell
+ *  Copyright (C) 2004 Ben Goodrich aka bbitmaster <bbitmaster@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/drivers/win/ppuview.cpp
+++ b/src/drivers/win/ppuview.cpp
@@ -1,7 +1,7 @@
 /* FCE Ultra - NES/Famicom Emulator
  *
  * Copyright notice for this file:
- *  Copyright (C) 2002 Ben Parnell
+ *  Copyright (C) 2002 Jay Oster aka Parasyte <jay@kodewerx.org>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/drivers/win/texthook.cpp
+++ b/src/drivers/win/texthook.cpp
@@ -1,7 +1,7 @@
 /* FCE Ultra - NES/Famicom Emulator
  *
  * Copyright notice for this file:
- *  Copyright (C) 2002 Ben Parnell
+ *  Copyright (C) 2005 UglyJoe
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/drivers/win/tracer.cpp
+++ b/src/drivers/win/tracer.cpp
@@ -1,7 +1,7 @@
 /* FCE Ultra - NES/Famicom Emulator
  *
  * Copyright notice for this file:
- *  Copyright (C) 2002 Ben Parnell
+ *  Copyright (C) 2004 Ben Goodrich aka bbitmaster <bbitmaster@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
This change de-duplicates Xodnizel's identity in some "About" windows.

Closes #753