### PR TITLE
Fix PRG reads and writes in CD Logger

### DIFF
--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -569,7 +569,12 @@ void LogCDData(uint8 *opcode, uint16 A, int size)
 				newDataHit = true;
 			}
 		}
-		else
+		// Unclear why the write destination's access types gets reset for FDS...
+		// See:
+		// - https://github.com/TASEmulators/fceux/commit/a4fa6225a04b5ab8d3dfca3fc9abd7190bceec85
+		// - https://github.com/TASEmulators/fceux/commit/b10b6254c3d5c9519a85cb4382cdb22846d2e394
+		// - https://github.com/TASEmulators/fceux/commit/67942accc72149ae028d58f36419b64ea8651db9?diff=unified&w=1
+		else if(GameInfo && GameInfo->type == GIT_FDS)
 		{
 			if (cdloggerdata[j] & 1)
 			{

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -554,7 +554,7 @@ void LogCDData(uint8 *opcode, uint16 A, int size)
 		case 4: memop = 0x20; break;
 	}
 
-	if ((j = GetPRGAddress(A)) != -1)
+	if (((j = GetPRGAddress(A)) != -1) && (opcode[0] != 0x4C) && (opcode[0] != 0x6C))
 	{
 		if (opwrite[opcode[0]] == 0)
 		{


### PR DESCRIPTION
This code was added for FDS RAM, but it breaks PRG writes with normal cartridge-based memory controllers.

The bug inappropriately resets (clears) the access mode bits previously recorded when an MMIO register is written in PRG address space. For instance, if an instruction is executed at $8000 and then some code later writes to $8000, the instruction execution would have been forgotten.

The bug was a regression introduced in 2.4.0.