### PR TITLE
Fix PRG bank shown in debugger

### DIFF
--- a/src/cart.h
+++ b/src/cart.h
@@ -92,6 +92,7 @@ void ResetCartMapping(void);
 void SetupCartPRGMapping(int chip, uint8 *p, uint32 size, int ram);
 void SetupCartCHRMapping(int chip, uint8 *p, uint32 size, int ram);
 void SetupCartMirroring(int m, int hard, uint8 *extra);
+int GetPRGBank(uint16 address);
 
 DECLFR(CartBROB);
 DECLFR(CartBR);

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -288,8 +288,6 @@ int GetPRGAddress(int A){
 
 /**
 * Returns the bank for a given offset.
-* Technically speaking this function does not calculate the actual bank
-* where the offset resides but the 0x4000 bytes large chunk of the ROM of the offset.
 *
 * @param offs The offset
 * @return The bank of that offset or -1 if the offset is not part of the ROM.
@@ -298,13 +296,13 @@ int getBank(int offs)
 {
 	//NSF data is easy to overflow the return on.
 	//Anything over FFFFF will kill it.
+	if (GameInfo && GameInfo->type == GIT_NSF) {
+		int addr = GetNesFileAddress(offs) - NES_HEADER_SIZE;
 
-	//GetNesFileAddress doesn't work well with Unif files
-	int addr = GetNesFileAddress(offs)-NES_HEADER_SIZE;
-
-	if (GameInfo && GameInfo->type==GIT_NSF)
 		return addr != -1 ? addr / 0x1000 : -1;
-	return addr != -1 ? addr / (1<<debuggerPageSize) : -1; //formerly, dividing by 0x4000
+	}
+
+	return ((offs >= 0x6000) && (offs <= 0xFFFF)) ? GetPRGBank(offs) : -1;
 }
 
 int GetNesFileAddress(int A){


### PR DESCRIPTION
The old code used a hardcoded 16 KiB bank size, regardless of how the mapper actually maps banks.

There is still a lot of code making this assumption. See `debuggerPageSize`. Mostly for symbolic debugging.

----

TBD: This PR is a draft because it may be confusing if the mapper simultaneously uses varying bank sizes.