### PR TITLE
Use proper symbol name checking for arm64

### DIFF
--- a/src/utils/timeStamp.cpp
+++ b/src/utils/timeStamp.cpp
@@ -26,7 +26,7 @@
 
 static uint64_t rdtsc()
 {
-#if defined(__arm64__) || defined(__arm__)
+#if defined(__aarch64__) || defined(__arm__)
     // SPDX-License-Identifier: GPL-2.0
     uint64_t val = 0;
 


### PR DESCRIPTION
The proper symbol for checking for 64-bit ARM is ```__aarch64__```