### PR TITLE
Fix build against x265 build 214 and above

### DIFF
--- a/src/drivers/Qt/AviRecord.cpp
+++ b/src/drivers/Qt/AviRecord.cpp
@@ -461,8 +461,8 @@ static int encode_frame( unsigned char *inBuf, int width, int height )
 	pic->stride[1] = width/2;
 	pic->stride[2] = width/2;
 
-#ifdef MAX_SCALABLE_LAYERS
-	/* Handle API changes for scalable layers output in x265 4.0 */
+#if X265_BUILD >= 210 && X265_BUILD <= 213 && defined(MAX_SCALABLE_LAYERS)
+	/* Handle temporary API changes for scalable layers output in x265 4.0 */
 	x265_picture *pics[MAX_SCALABLE_LAYERS] = {NULL};
 	pics[0] = pic;
 	ret = x265_encoder_encode( hdl, &nal, &i_nal, pic, pics );
@@ -501,8 +501,8 @@ static int close(void)
 	/* Flush delayed frames */
 	while( hdl != NULL )
 	{
-#ifdef MAX_SCALABLE_LAYERS
-	    /* Handle API changes for scalable layers output in x265 4.0 */
+#if X265_BUILD >= 210 && X265_BUILD <= 213 && defined(MAX_SCALABLE_LAYERS)
+	    /* Handle temporary API changes for scalable layers output in x265 4.0 */
 	    x265_picture *pics[MAX_SCALABLE_LAYERS] = {NULL};
 	    pics[0] = pic;
 	    ret = x265_encoder_encode( hdl, &nal, &i_nal, pic, pics );


### PR DESCRIPTION
I discovered that our workaround to call the x265 API was breaking the build, so I apply it more judiciously based on research into changes to the x265 codebase.

The current workaround breaks when building against x265 version 214 and above, and even some development versions of 213.

It's still not a perfect check. There's still a range of x265 commits from 2024-10-04 to 2024-11-12 where fceux will not build against the development version of x265. If that's the case, just update to the latest x265.

I don't believe there can be a perfect check because the commit in the x265 repo that introduces the API change we're working around doesn't bump the X265_BUILD constant like it probably should have. The revert ALSO doesn't bump it, so we have to do what we can here.

Research shows:

https://bitbucket.org/multicoreware/x265_git/commits/c8c9d22075b26aa279b4d634c61889ca3d49656e:
- X265_BUILD: 209 -> 210
- MAX_SCALABLE_LAYERS: undefined
- Our workaround: Skipped, build works

https://bitbucket.org/multicoreware/x265_git/commits/c69c113960834400545bc4bce2830ff51dcb86b3:
- x265 API change is introduced in this commit
- X265_BUILD: 210
- MAX_SCALABLE_LAYERS: defined
- Our workaround: Applied, build works

https://bitbucket.org/multicoreware/x265_git/commits/78e5b703b186fe184bf91bb37df82f64059b3f61:
- x265 API change is reverted in this commit
- X265_BUILD: 213
- MAX_SCALABLE_LAYERS: still defined
- Our workaround: Applied, unfortunately. Start of broken commit range.

https://bitbucket.org/multicoreware/x265_git/commits/451add89e81d45134b9d41168ceeb5516bf62d0b:
- X265_BUILD: 213 -> 214
- MAX_SCALABLE_LAYERS: still defined
- Our workaround: Back to skipped. Build is fixed. End of broken commit range.