### PR TITLE
chore: scope the patch for x265 4.0 build

### DIFF
--- a/src/drivers/Qt/AviRecord.cpp
+++ b/src/drivers/Qt/AviRecord.cpp
@@ -461,7 +461,7 @@ static int encode_frame( unsigned char *inBuf, int width, int height )
 	pic->stride[1] = width/2;
 	pic->stride[2] = width/2;
 
-#ifdef MAX_SCALABLE_LAYERS
+#if defined(MAX_SCALABLE_LAYERS) && (X265_BUILD >= 210) && (X265_BUILD < 213)
 	/* Handle API changes for scalable layers output in x265 4.0 */
 	x265_picture *pics[MAX_SCALABLE_LAYERS] = {NULL};
 	pics[0] = pic;
@@ -501,7 +501,7 @@ static int close(void)
 	/* Flush delayed frames */
 	while( hdl != NULL )
 	{
-#ifdef MAX_SCALABLE_LAYERS
+#if defined(MAX_SCALABLE_LAYERS) && (X265_BUILD >= 210) && (X265_BUILD < 213)
 	    /* Handle API changes for scalable layers output in x265 4.0 */
 	    x265_picture *pics[MAX_SCALABLE_LAYERS] = {NULL};
 	    pics[0] = pic;


### PR DESCRIPTION
Reverts TASEmulators/fceux#766

upstream has reverted the x265_encoder_encode api change in https://bitbucket.org/multicoreware/x265_git/commits/78e5b703b186fe184bf91bb37df82f64059b3f61 per 4.1 release, thus the patch is no longer needed, hence reverting for now. (previous 4.0 API change commit, https://bitbucket.org/multicoreware/x265_git/commits/c69c113960834400545bc4bce2830ff51dcb86b3)

relates to https://github.com/Homebrew/homebrew-core/pull/198642