### PR TITLE
Reimplement mapper 92 correctly

### DIFF
--- a/src/boards/18.cpp
+++ b/src/boards/18.cpp
@@ -16,6 +16,9 @@
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * The Moero!! Pro Yakyuu series have an ADPCM chip with internal ROM,
+ * used for voice samples (not dumped, so emulation isn't possible)
  */
 
 #include "mapinc.h"

--- a/src/boards/addrlatch.cpp
+++ b/src/boards/addrlatch.cpp
@@ -181,6 +181,7 @@ void Mapper59_Init(CartInfo *info) {
 }
 
 //------------------ Map 061 ---------------------------
+
 static void M61Sync(void) {
 	if (((latche & 0x10) << 1) ^ (latche & 0x20)) {
 		setprg16(0x8000, ((latche & 0xF) << 1) | (((latche & 0x20) >> 4)));
@@ -193,32 +194,6 @@ static void M61Sync(void) {
 
 void Mapper61_Init(CartInfo *info) {
 	Latch_Init(info, M61Sync, NULL, 0x0000, 0x8000, 0xFFFF, 0);
-}
-
-//------------------ Map 092 ---------------------------
-// Another two-in-one mapper, two Jaleco carts uses similar
-// hardware, but with different wiring.
-// Original code provided by LULU
-// Additionally, PCB contains DSP extra sound chip, used for voice samples (unemulated)
-
-static void M92Sync(void) {
-	uint8 reg = latche & 0xF0;
-	setprg16(0x8000, 0);
-	if (latche >= 0x9000) {
-		switch (reg) {
-		case 0xD0: setprg16(0xc000, latche & 15); break;
-		case 0xE0: setchr8(latche & 15); break;
-		}
-	} else {
-		switch (reg) {
-		case 0xB0: setprg16(0xc000, latche & 15); break;
-		case 0x70: setchr8(latche & 15); break;
-		}
-	}
-}
-
-void Mapper92_Init(CartInfo *info) {
-	Latch_Init(info, M92Sync, NULL, 0x80B0, 0x8000, 0xFFFF, 0);
 }
 
 //------------------ Map 174 ---------------------------

--- a/src/boards/datalatch.cpp
+++ b/src/boards/datalatch.cpp
@@ -309,7 +309,8 @@ void Mapper78_Init(CartInfo *info) {
 }
 
 //------------------ Map 86 ---------------------------
-
+// Moero!! Pro Yakyuu has an ADPCM chip with internal ROM,
+// used for voice samples (not dumped, so emulation isn't possible)
 static void M86Sync(void) {
 	setprg32(0x8000, (latche >> 4) & 3);
 	setchr8((latche & 3) | ((latche >> 4) & 4));


### PR DESCRIPTION
Mapper 92 (Moero!! Pro Yakyuu '88 and Moero!! Pro Soccer) is incorrectly implemented as an address latch based mapper, when it's actually a variant of Mapper 72. Move implementation to the right place. Also, copy the comment in `72.cpp` about unemulated ADPCM chips to all relevant Jaleco mappers.